### PR TITLE
Use InvariantCulture for Convert.ToDouble

### DIFF
--- a/PokeViewer.NET/MainViewer.cs
+++ b/PokeViewer.NET/MainViewer.cs
@@ -11,6 +11,7 @@ using PokeViewer.NET.SubForms;
 using PokeViewer.NET.WideViewForms;
 using SysBot.Base;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Compression;
 using System.Net.Sockets;
 using System.Reflection;
@@ -75,7 +76,7 @@ namespace PokeViewer.NET
             var sbb = await Executor.SwitchConnection.GetBotbaseVersion(token).ConfigureAwait(false);
             string replacement = Regex.Replace(sbb, @"\t|\n|\r", "");
             string vIn = replacement.Replace('"', ' ').Trim();
-            var vOut = Convert.ToDouble(vIn);
+            var vOut = Convert.ToDouble(vIn, CultureInfo.InvariantCulture);
             if (vOut < 2.4)
             {
                 DialogResult dialogResult = MessageBox.Show($"Current version of sysbot-base v{sbb.ToString().TrimEnd('\r', '\n')} does not match minimum required version. Download latest?", "An update is available", MessageBoxButtons.YesNo, MessageBoxIcon.Question);


### PR DESCRIPTION
Should fix issue parsing sys-botbase version for users on localizations that don't use ``.`` as a decimal point
![image](https://github.com/user-attachments/assets/63edf8a9-4f4f-4066-a30d-360dd1923d52)
